### PR TITLE
add Migrations for ? in player names

### DIFF
--- a/config/migrations.yml
+++ b/config/migrations.yml
@@ -1,0 +1,22 @@
+services:
+    _defaults:
+        autoconfigure: true
+
+    _instanceof:
+        Contao\CoreBundle\Framework\FrameworkAwareInterface:
+            calls:
+                - ["setFramework", ["@contao.framework"]]
+
+    janborg.h4agamestats.migration.playerscores:
+        class: Janborg\H4aGamestats\Migration\WronglyEncodedPlayerscoresMigration
+        arguments:
+            - "@database_connection"
+            - "@contao.framework"
+            - "@contao.cache.entity_tags"
+
+    janborg.h4agamestats.migration.timelines:
+        class: Janborg\H4aGamestats\Migration\WronglyEncodedTimelinesMigration
+        arguments:
+            - "@database_connection"
+            - "@contao.framework"
+            - "@contao.cache.entity_tags"

--- a/src/DependencyInjection/JanborgH4aGamestatsExtension.php
+++ b/src/DependencyInjection/JanborgH4aGamestatsExtension.php
@@ -33,5 +33,6 @@ class JanborgH4aGamestatsExtension extends Extension
         $loader->load('controller.yml');
         $loader->load('services.yml');
         $loader->load('listener.yml');
+        $loader->load('migrations.yml');
     }
 }

--- a/src/Migration/WronglyEncodedPlayerscoresMigration.php
+++ b/src/Migration/WronglyEncodedPlayerscoresMigration.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of contao-h4a_gamestats.
+ *
+ * (c) Jan Lünborg
+ *
+ * @license MIT
+ */
+
+namespace Janborg\H4aGamestats\Migration;
+
+use Contao\CalendarEventsModel;
+use Contao\CoreBundle\Cache\EntityCacheTags;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+use Janborg\H4aGamestats\H4aReport\H4aReportParser;
+use Janborg\H4aGamestats\Model\H4aPlayerscoresModel;
+
+class WronglyEncodedPlayerscoresMigration extends AbstractMigration
+{
+    public function __construct(
+        private Connection $connection,
+        private ContaoFramework $framework,
+        private EntityCacheTags $entityCacheTags,
+    ) {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        // If the database table already itself exists we should do nothing
+        if (!$schemaManager->tablesExist(['tl_h4a_playerscores'])) {
+            return false;
+        }
+
+        $stmt = $this->connection->executeQuery('
+            SELECT id, name FROM tl_h4a_playerscores
+        ');
+
+        $allPlayerNames = $stmt->fetchAllAssociative();
+
+        $wrongEncodedPlayerNames = array_filter(
+            $allPlayerNames,
+            static fn ($player): bool => (bool) preg_match('/\?/', $player['name']),
+        );
+
+        return !empty($wrongEncodedPlayerNames);
+    }
+
+    public function run(): MigrationResult
+    {
+        $this->framework->initialize();
+
+        $stmt = $this->connection->executeQuery('
+            SELECT id, pid, name FROM tl_h4a_playerscores
+        ');
+
+        $allPlayerNames = $stmt->fetchAllAssociative();
+
+        $wrongEncodedPlayerNames = array_filter(
+            $allPlayerNames,
+            static fn ($player): bool => (bool) preg_match('/\?/', $player['name']),
+        );
+
+        foreach ($wrongEncodedPlayerNames as $playerscore) {
+            $objCalendarEvent = CalendarEventsModel::findById($playerscore['pid']);
+
+            $h4areportparser = new H4aReportParser($objCalendarEvent->sGID);
+
+            $h4areportparser->parseReport();
+
+            // Spieler der Heimmannschaft speichern
+            H4aPlayerscoresModel::savePlayerscores($h4areportparser->home_team, $objCalendarEvent->id, $h4areportparser->heim_name, $home_guest = 1);
+
+            // Spieler der Gastmannschaft speichern
+            H4aPlayerscoresModel::savePlayerscores($h4areportparser->guest_team, $objCalendarEvent->id, $h4areportparser->gast_name, $home_guest = 2);
+
+            // Delete the old Playerscore
+            H4aPlayerscoresModel::findById($playerscore['id'])->delete();
+
+            $this->entityCacheTags->invalidateTagsFor($objCalendarEvent);
+        }
+
+        return $this->createResult(
+            true,
+            'Updated '.\count($wrongEncodedPlayerNames).' playerscore.',
+        );
+    }
+}

--- a/src/Migration/WronglyEncodedPlayerscoresMigration.php
+++ b/src/Migration/WronglyEncodedPlayerscoresMigration.php
@@ -42,7 +42,7 @@ class WronglyEncodedPlayerscoresMigration extends AbstractMigration
         $results = $this->connection->fetchAllAssociative(
             "SELECT id, name
                FROM tl_h4a_playerscores
-              WHERE tl_h4a_playerscores.name LIKE '%\?%'"
+              WHERE tl_h4a_playerscores.name LIKE '%\\?%'",
         );
 
         return !empty($results);
@@ -55,11 +55,10 @@ class WronglyEncodedPlayerscoresMigration extends AbstractMigration
         $wronglyEncodedPlayerNames = $this->connection->fetchAllAssociative(
             "SELECT id, pid, name
                FROM tl_h4a_playerscores
-              WHERE tl_h4a_playerscores.name LIKE '%\?%'"
+              WHERE tl_h4a_playerscores.name LIKE '%\\?%'",
         );
 
         foreach ($wronglyEncodedPlayerNames as $playerscore) {
-
             $objCalendarEvent = CalendarEventsModel::findById($playerscore['pid']);
 
             $h4areportparser = new H4aReportParser($objCalendarEvent->sGID);

--- a/src/Migration/WronglyEncodedPlayerscoresMigration.php
+++ b/src/Migration/WronglyEncodedPlayerscoresMigration.php
@@ -39,36 +39,27 @@ class WronglyEncodedPlayerscoresMigration extends AbstractMigration
             return false;
         }
 
-        $stmt = $this->connection->executeQuery('
-            SELECT id, name FROM tl_h4a_playerscores
-        ');
-
-        $allPlayerNames = $stmt->fetchAllAssociative();
-
-        $wrongEncodedPlayerNames = array_filter(
-            $allPlayerNames,
-            static fn ($player): bool => (bool) preg_match('/\?/', $player['name']),
+        $results = $this->connection->fetchAllAssociative(
+            "SELECT id, name
+               FROM tl_h4a_playerscores
+              WHERE tl_h4a_playerscores.name LIKE '%\?%'"
         );
 
-        return !empty($wrongEncodedPlayerNames);
+        return !empty($results);
     }
 
     public function run(): MigrationResult
     {
         $this->framework->initialize();
 
-        $stmt = $this->connection->executeQuery('
-            SELECT id, pid, name FROM tl_h4a_playerscores
-        ');
-
-        $allPlayerNames = $stmt->fetchAllAssociative();
-
-        $wrongEncodedPlayerNames = array_filter(
-            $allPlayerNames,
-            static fn ($player): bool => (bool) preg_match('/\?/', $player['name']),
+        $wronglyEncodedPlayerNames = $this->connection->fetchAllAssociative(
+            "SELECT id, pid, name
+               FROM tl_h4a_playerscores
+              WHERE tl_h4a_playerscores.name LIKE '%\?%'"
         );
 
-        foreach ($wrongEncodedPlayerNames as $playerscore) {
+        foreach ($wronglyEncodedPlayerNames as $playerscore) {
+
             $objCalendarEvent = CalendarEventsModel::findById($playerscore['pid']);
 
             $h4areportparser = new H4aReportParser($objCalendarEvent->sGID);
@@ -89,7 +80,7 @@ class WronglyEncodedPlayerscoresMigration extends AbstractMigration
 
         return $this->createResult(
             true,
-            'Updated '.\count($wrongEncodedPlayerNames).' playerscore.',
+            'Updated '.\count($wronglyEncodedPlayerNames).' playerscore items.',
         );
     }
 }

--- a/src/Migration/WronglyEncodedTimelinesMigration.php
+++ b/src/Migration/WronglyEncodedTimelinesMigration.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of contao-h4a_gamestats.
+ *
+ * (c) Jan Lünborg
+ *
+ * @license MIT
+ */
+
+namespace Janborg\H4aGamestats\Migration;
+
+use Contao\CalendarEventsModel;
+use Contao\CoreBundle\Cache\EntityCacheTags;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+use Janborg\H4aGamestats\H4aReport\H4aReportParser;
+use Janborg\H4aGamestats\Model\H4aTimelineModel;
+
+class WronglyEncodedTimelinesMigration extends AbstractMigration
+{
+    public function __construct(
+        private Connection $connection,
+        private ContaoFramework $framework,
+        private EntityCacheTags $entityCacheTags,
+    ) {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        // If the database table already itself exists we should do nothing
+        if (!$schemaManager->tablesExist(['tl_h4a_timeline'])) {
+            return false;
+        }
+
+        $stmt = $this->connection->executeQuery('
+            SELECT id, action_player FROM tl_h4a_timeline
+        ');
+
+        $allPlayerNames = $stmt->fetchAllAssociative();
+
+        $wrongEncodedPlayerNames = array_filter(
+            $allPlayerNames,
+            static fn ($player): bool => (bool) preg_match('/\?/', $player['action_player']),
+        );
+
+        return !empty($wrongEncodedPlayerNames);
+    }
+
+    public function run(): MigrationResult
+    {
+        $this->framework->initialize();
+
+        $stmt = $this->connection->executeQuery('
+            SELECT id, pid, action_player FROM tl_h4a_timeline
+        ');
+
+        $allPlayerNames = $stmt->fetchAllAssociative();
+
+        $wrongEncodedPlayerNames = array_filter(
+            $allPlayerNames,
+            static fn ($player): bool => (bool) preg_match('/\?/', $player['action_player']),
+        );
+
+        foreach ($wrongEncodedPlayerNames as $player) {
+            $objCalendarEvent = CalendarEventsModel::findById($player['pid']);
+
+            $h4areportparser = new H4aReportParser($objCalendarEvent->sGID);
+
+            $h4areportparser->parseReport();
+
+            // Timeline des Spiels abrufen
+            H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objCalendarEvent->id);
+
+            // Delete the old Timeline Item
+            H4aTimelineModel::findById($player['id'])->delete();
+
+            $this->entityCacheTags->invalidateTagsFor($objCalendarEvent);
+        }
+
+        return $this->createResult(
+            true,
+            'Updated '.\count($wrongEncodedPlayerNames).' timeline item.',
+        );
+    }
+}

--- a/src/Migration/WronglyEncodedTimelinesMigration.php
+++ b/src/Migration/WronglyEncodedTimelinesMigration.php
@@ -42,7 +42,7 @@ class WronglyEncodedTimelinesMigration extends AbstractMigration
         $results = $this->connection->fetchAllAssociative(
             "SELECT id, action_player
                FROM tl_h4a_timeline
-              WHERE tl_h4a_timeline.action_player LIKE '%\?%'"
+              WHERE tl_h4a_timeline.action_player LIKE '%\\?%'",
         );
 
         return !empty($results);
@@ -55,11 +55,10 @@ class WronglyEncodedTimelinesMigration extends AbstractMigration
         $wronglyEncodedPlayerNames = $this->connection->fetchAllAssociative(
             "SELECT id, pid, action_player
                FROM tl_h4a_timeline
-              WHERE tl_h4a_timeline.action_player LIKE '%\?%'"
+              WHERE tl_h4a_timeline.action_player LIKE '%\\?%'",
         );
 
         foreach ($wronglyEncodedPlayerNames as $player) {
-
             $objCalendarEvent = CalendarEventsModel::findById($player['pid']);
 
             $h4areportparser = new H4aReportParser($objCalendarEvent->sGID);

--- a/src/Migration/WronglyEncodedTimelinesMigration.php
+++ b/src/Migration/WronglyEncodedTimelinesMigration.php
@@ -39,36 +39,27 @@ class WronglyEncodedTimelinesMigration extends AbstractMigration
             return false;
         }
 
-        $stmt = $this->connection->executeQuery('
-            SELECT id, action_player FROM tl_h4a_timeline
-        ');
-
-        $allPlayerNames = $stmt->fetchAllAssociative();
-
-        $wrongEncodedPlayerNames = array_filter(
-            $allPlayerNames,
-            static fn ($player): bool => (bool) preg_match('/\?/', $player['action_player']),
+        $results = $this->connection->fetchAllAssociative(
+            "SELECT id, action_player
+               FROM tl_h4a_timeline
+              WHERE tl_h4a_timeline.action_player LIKE '%\?%'"
         );
 
-        return !empty($wrongEncodedPlayerNames);
+        return !empty($results);
     }
 
     public function run(): MigrationResult
     {
         $this->framework->initialize();
 
-        $stmt = $this->connection->executeQuery('
-            SELECT id, pid, action_player FROM tl_h4a_timeline
-        ');
-
-        $allPlayerNames = $stmt->fetchAllAssociative();
-
-        $wrongEncodedPlayerNames = array_filter(
-            $allPlayerNames,
-            static fn ($player): bool => (bool) preg_match('/\?/', $player['action_player']),
+        $wronglyEncodedPlayerNames = $this->connection->fetchAllAssociative(
+            "SELECT id, pid, action_player
+               FROM tl_h4a_timeline
+              WHERE tl_h4a_timeline.action_player LIKE '%\?%'"
         );
 
-        foreach ($wrongEncodedPlayerNames as $player) {
+        foreach ($wronglyEncodedPlayerNames as $player) {
+
             $objCalendarEvent = CalendarEventsModel::findById($player['pid']);
 
             $h4areportparser = new H4aReportParser($objCalendarEvent->sGID);
@@ -86,7 +77,7 @@ class WronglyEncodedTimelinesMigration extends AbstractMigration
 
         return $this->createResult(
             true,
-            'Updated '.\count($wrongEncodedPlayerNames).' timeline item.',
+            'Updated '.\count($wronglyEncodedPlayerNames).' timeline items.',
         );
     }
 }


### PR DESCRIPTION
In aktuellen Java Evironments werden ä,ö,ü,ß nicht mehr korrekt ausgegeben, sondern als ?.

In #28 wurde es bereits korrigiert, sodass neue Spielberichte korrekt umgewandelt werden.

In diesem PR werden nun die fehlerhaften Einträge, die sich bereits in der DB befinden bereinigt bzw. korrigiert.