### PR TITLE
add error handling for parsing reports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "contao/calendar-bundle": "^4.13 || ^5.3",
         "doctrine/dbal": "^3.6",
         "janborg/contao-h4a_tabellen": "^2.5",
+        "psr/log": "^1.1 || 2.0 || ^3.0",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/console": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",

--- a/config/controller.yml
+++ b/config/controller.yml
@@ -12,6 +12,7 @@ services:
             - '@contao.cache.entity_tags'
             - '@h4atabellen.h4aapihelper'
             - '@monolog.logger.contao.general'
+            - '@monolog.logger.contao.error'
 
     Janborg\H4aGamestats\Backend\LookupTimelineController:
         public: true
@@ -19,3 +20,4 @@ services:
             - '@contao.cache.entity_tags'
             - '@h4atabellen.h4aapihelper'
             - '@monolog.logger.contao.general'
+            - '@monolog.logger.contao.error'

--- a/config/services.yml
+++ b/config/services.yml
@@ -25,6 +25,7 @@ services:
             - '@contao.framework'
             - '@contao.cache.entity_tags'
             - '@monolog.logger.contao.cron'
+            - '@monolog.logger.contao.error'
             - '@h4atabellen.h4aapihelper'
         tags:
             -
@@ -39,6 +40,7 @@ services:
             - '@contao.framework'
             - '@contao.cache.entity_tags'
             - '@monolog.logger.contao.cron'
+            - '@monolog.logger.contao.error'
             - '@h4atabellen.h4aapihelper'
         tags:
             -

--- a/src/Backend/LookupScoresController.php
+++ b/src/Backend/LookupScoresController.php
@@ -16,11 +16,11 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
-use Psr\Log\LoggerInterface;
 use Contao\Input;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aPlayerscoresModel;
 use Janborg\H4aTabellen\Helper\H4aApiHelper;
+use Psr\Log\LoggerInterface;
 
 class LookupScoresController extends Backend
 {
@@ -55,17 +55,15 @@ class LookupScoresController extends Backend
         }
 
         $h4areportparser = new H4aReportParser($sGID);
-        
+
         try {
-            $h4areportparser->parseReport();    
+            $h4areportparser->parseReport();
         } catch (\Exception $e) {
             $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.']: '.$e->getMessage());
-            
+
             $this->redirect($this->getReferer());
-            
-            return;
         }
-        
+
         // Spieler der Heimmannschaft speichern
         H4aPlayerscoresModel::savePlayerscores($h4areportparser->home_team, $objCalendarEvent->id, $h4areportparser->heim_name, $home_guest = 1);
 

--- a/src/Backend/LookupScoresController.php
+++ b/src/Backend/LookupScoresController.php
@@ -16,7 +16,7 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
-use Contao\CoreBundle\Monolog\SystemLogger;
+use Psr\Log\LoggerInterface;
 use Contao\Input;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aPlayerscoresModel;
@@ -27,7 +27,8 @@ class LookupScoresController extends Backend
     public function __construct(
         private EntityCacheTags $entityCacheTags,
         private H4aApiHelper $h4aApiHelper,
-        private SystemLogger|null $systemLogger,
+        private readonly LoggerInterface $contaoGeneralLogger,
+        private readonly LoggerInterface $contaoErrorLogger,
     ) {
         parent::__construct();
         $this->import(BackendUser::class, 'User');
@@ -63,7 +64,7 @@ class LookupScoresController extends Backend
         // Spieler der Gastmannschaft speichern
         H4aPlayerscoresModel::savePlayerscores($h4areportparser->guest_team, $objCalendarEvent->id, $h4areportparser->gast_name, $home_guest = 2);
 
-        $this->systemLogger?->info('Playerscores für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.'] gespeichert.');
+        $this->contaoGeneralLogger->info('Playerscores für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.'] gespeichert.');
 
         $this->entityCacheTags->invalidateTagsFor($objCalendarEvent);
 

--- a/src/Backend/LookupScoresController.php
+++ b/src/Backend/LookupScoresController.php
@@ -55,9 +55,17 @@ class LookupScoresController extends Backend
         }
 
         $h4areportparser = new H4aReportParser($sGID);
-
-        $h4areportparser->parseReport();
-
+        
+        try {
+            $h4areportparser->parseReport();    
+        } catch (\Exception $e) {
+            $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.']: '.$e->getMessage());
+            
+            $this->redirect($this->getReferer());
+            
+            return;
+        }
+        
         // Spieler der Heimmannschaft speichern
         H4aPlayerscoresModel::savePlayerscores($h4areportparser->home_team, $objCalendarEvent->id, $h4areportparser->heim_name, $home_guest = 1);
 

--- a/src/Backend/LookupTimelineController.php
+++ b/src/Backend/LookupTimelineController.php
@@ -16,7 +16,7 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
-use Contao\CoreBundle\Monolog\SystemLogger;
+use Psr\Log\LoggerInterface;
 use Contao\Input;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aTimelineModel;
@@ -27,7 +27,8 @@ class LookupTimelineController extends Backend
     public function __construct(
         private EntityCacheTags $entityCacheTags,
         private H4aApiHelper $h4aApiHelper,
-        private SystemLogger|null $systemLogger,
+        private readonly LoggerInterface $contaoGeneralLogger,
+        private readonly LoggerInterface $contaoErrorLogger,
     ) {
         parent::__construct();
         $this->import(BackendUser::class, 'User');
@@ -59,7 +60,7 @@ class LookupTimelineController extends Backend
 
         H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objCalendarEvent->id);
 
-        $this->systemLogger?->info('Timeline für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.'] gespeichert.');
+        $this->contaoGeneralLogger->info('Timeline für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.'] gespeichert.');
 
         $this->entityCacheTags->invalidateTagsFor($objCalendarEvent);
 

--- a/src/Backend/LookupTimelineController.php
+++ b/src/Backend/LookupTimelineController.php
@@ -56,7 +56,15 @@ class LookupTimelineController extends Backend
 
         $h4areportparser = new H4aReportParser($sGID);
 
-        $h4areportparser->parseReport();
+        try {
+            $h4areportparser->parseReport();    
+        } catch (\Exception $e) {
+            $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.']: '.$e->getMessage());
+            
+            $this->redirect($this->getReferer());
+            
+            return;
+        }
 
         H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objCalendarEvent->id);
 

--- a/src/Backend/LookupTimelineController.php
+++ b/src/Backend/LookupTimelineController.php
@@ -16,11 +16,11 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
-use Psr\Log\LoggerInterface;
 use Contao\Input;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aTimelineModel;
 use Janborg\H4aTabellen\Helper\H4aApiHelper;
+use Psr\Log\LoggerInterface;
 
 class LookupTimelineController extends Backend
 {
@@ -57,13 +57,11 @@ class LookupTimelineController extends Backend
         $h4areportparser = new H4aReportParser($sGID);
 
         try {
-            $h4areportparser->parseReport();    
+            $h4areportparser->parseReport();
         } catch (\Exception $e) {
             $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objCalendarEvent->gGameNo.' ['.$objCalendarEvent->title.']: '.$e->getMessage());
-            
+
             $this->redirect($this->getReferer());
-            
-            return;
         }
 
         H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objCalendarEvent->id);

--- a/src/Command/UpdateH4aScoresCommand.php
+++ b/src/Command/UpdateH4aScoresCommand.php
@@ -109,10 +109,10 @@ class UpdateH4aScoresCommand extends Command
             $h4areportparser = new H4aReportParser($objEvent->sGID);
 
             try {
-                $h4areportparser->parseReport();    
+                $h4areportparser->parseReport();
             } catch (\Exception $e) {
                 $output->writeln('<error>Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage().'</error>');
-                
+
                 continue;
             }
 

--- a/src/Command/UpdateH4aScoresCommand.php
+++ b/src/Command/UpdateH4aScoresCommand.php
@@ -107,7 +107,14 @@ class UpdateH4aScoresCommand extends Command
                 continue;
             }
             $h4areportparser = new H4aReportParser($objEvent->sGID);
-            $h4areportparser->parseReport();
+
+            try {
+                $h4areportparser->parseReport();    
+            } catch (\Exception $e) {
+                $output->writeln('<error>Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage().'</error>');
+                
+                continue;
+            }
 
             // Spieler der Heim Mannschaft speichern
             H4aPlayerscoresModel::savePlayerscores($h4areportparser->home_team, $objEvent->id, $h4areportparser->heim_name, $home_guest = 1);

--- a/src/Command/UpdateH4aTimelineCommand.php
+++ b/src/Command/UpdateH4aTimelineCommand.php
@@ -104,9 +104,15 @@ class UpdateH4aTimelineCommand extends Command
 
                 continue;
             }
+            
             $h4areportparser = new H4aReportParser($objEvent->sGID);
-            $h4areportparser->parseReport();
-
+            
+            try {
+                $h4areportparser->parseReport();    
+            } catch (\Exception $e) {
+                $output->writeln('<error>Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage().'</error>');                
+                continue;
+            }
             // Spieler der Heim Mannschaft speichern
             H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objEvent->id);
 

--- a/src/Command/UpdateH4aTimelineCommand.php
+++ b/src/Command/UpdateH4aTimelineCommand.php
@@ -104,13 +104,13 @@ class UpdateH4aTimelineCommand extends Command
 
                 continue;
             }
-            
+
             $h4areportparser = new H4aReportParser($objEvent->sGID);
-            
+
             try {
-                $h4areportparser->parseReport();    
+                $h4areportparser->parseReport();
             } catch (\Exception $e) {
-                $output->writeln('<error>Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage().'</error>');                
+                $output->writeln('<error>Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage().'</error>');
                 continue;
             }
             // Spieler der Heim Mannschaft speichern

--- a/src/Cron/UpdateH4aScoresCron.php
+++ b/src/Cron/UpdateH4aScoresCron.php
@@ -15,10 +15,10 @@ namespace Janborg\H4aGamestats\Cron;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Psr\Log\LoggerInterface;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aPlayerscoresModel;
 use Janborg\H4aTabellen\Helper\H4aApiHelper;
+use Psr\Log\LoggerInterface;
 
 class UpdateH4aScoresCron
 {
@@ -62,12 +62,12 @@ class UpdateH4aScoresCron
             }
 
             $h4areportparser = new H4aReportParser($objEvent->sGID);
-            
+
             try {
-                $h4areportparser->parseReport();    
+                $h4areportparser->parseReport();
             } catch (\Exception $e) {
                 $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage());
-                
+
                 return;
             }
 

--- a/src/Cron/UpdateH4aScoresCron.php
+++ b/src/Cron/UpdateH4aScoresCron.php
@@ -62,7 +62,14 @@ class UpdateH4aScoresCron
             }
 
             $h4areportparser = new H4aReportParser($objEvent->sGID);
-            $h4areportparser->parseReport();
+            
+            try {
+                $h4areportparser->parseReport();    
+            } catch (\Exception $e) {
+                $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage());
+                
+                return;
+            }
 
             // Spieler der Heim Mannschaft speichern
             H4aPlayerscoresModel::savePlayerscores($h4areportparser->home_team, $objEvent->id, $h4areportparser->heim_name, $home_guest = 1);

--- a/src/Cron/UpdateH4aScoresCron.php
+++ b/src/Cron/UpdateH4aScoresCron.php
@@ -15,7 +15,7 @@ namespace Janborg\H4aGamestats\Cron;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\Monolog\SystemLogger;
+use Psr\Log\LoggerInterface;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aPlayerscoresModel;
 use Janborg\H4aTabellen\Helper\H4aApiHelper;
@@ -25,7 +25,8 @@ class UpdateH4aScoresCron
     public function __construct(
         private ContaoFramework $framework,
         private EntityCacheTags $entityCacheTags,
-        private SystemLogger|null $systemLogger,
+        private readonly LoggerInterface $contaoCronLogger,
+        private readonly LoggerInterface $contaoErrorLogger,
         private H4aApiHelper $h4aApiHelper,
     ) {
         $this->framework->initialize();
@@ -69,7 +70,7 @@ class UpdateH4aScoresCron
             // Spieler der Gast Mannschaft speichern
             H4aPlayerscoresModel::savePlayerscores($h4areportparser->guest_team, $objEvent->id, $h4areportparser->gast_name, $home_guest = 2);
 
-            $this->systemLogger?->info('Gamescores aus Bericht Nr. '.$objEvent->sGID
+            $this->contaoCronLogger->info('Gamescores aus Bericht Nr. '.$objEvent->sGID
                     .' für Spiel '.$objEvent->gGameID.' '.$h4areportparser->heim_name.' - '.$h4areportparser->gast_name
                     .' über Handball4all gespeichert');
 

--- a/src/Cron/UpdateH4aTimelineCron.php
+++ b/src/Cron/UpdateH4aTimelineCron.php
@@ -15,10 +15,10 @@ namespace Janborg\H4aGamestats\Cron;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Psr\Log\LoggerInterface;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aTimelineModel;
 use Janborg\H4aTabellen\Helper\H4aApiHelper;
+use Psr\Log\LoggerInterface;
 
 class UpdateH4aTimelineCron
 {
@@ -64,17 +64,17 @@ class UpdateH4aTimelineCron
             $h4areportparser = new H4aReportParser($objEvent->sGID);
 
             try {
-                $h4areportparser->parseReport();    
+                $h4areportparser->parseReport();
             } catch (\Exception $e) {
                 $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage());
-                
+
                 return;
             }
 
             // Timeline des Spiels speichern
             H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objEvent->id);
 
-            $this->contaoCronLogger?->info('Timeline aus Bericht Nr. '.$objEvent->sGID
+            $this->contaoCronLogger->info('Timeline aus Bericht Nr. '.$objEvent->sGID
                     .' für Spiel '.$objEvent->gGameID.' '.$h4areportparser->heim_name.' - '.$h4areportparser->gast_name
                     .' über Handball4all gespeichert');
 

--- a/src/Cron/UpdateH4aTimelineCron.php
+++ b/src/Cron/UpdateH4aTimelineCron.php
@@ -62,7 +62,14 @@ class UpdateH4aTimelineCron
             }
 
             $h4areportparser = new H4aReportParser($objEvent->sGID);
-            $h4areportparser->parseReport();
+
+            try {
+                $h4areportparser->parseReport();    
+            } catch (\Exception $e) {
+                $this->contaoErrorLogger->error('Fehler beim Abrufen des Spielberichts für Spiel '.$objEvent->gGameNo.' ['.$objEvent->title.']: '.$e->getMessage());
+                
+                return;
+            }
 
             // Timeline des Spiels speichern
             H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objEvent->id);

--- a/src/Cron/UpdateH4aTimelineCron.php
+++ b/src/Cron/UpdateH4aTimelineCron.php
@@ -15,7 +15,7 @@ namespace Janborg\H4aGamestats\Cron;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\Monolog\SystemLogger;
+use Psr\Log\LoggerInterface;
 use Janborg\H4aGamestats\H4aReport\H4aReportParser;
 use Janborg\H4aGamestats\Model\H4aTimelineModel;
 use Janborg\H4aTabellen\Helper\H4aApiHelper;
@@ -25,7 +25,8 @@ class UpdateH4aTimelineCron
     public function __construct(
         private ContaoFramework $framework,
         private EntityCacheTags $entityCacheTags,
-        private SystemLogger|null $systemLogger,
+        private readonly LoggerInterface $contaoCronLogger,
+        private readonly LoggerInterface $contaoErrorLogger,
         private H4aApiHelper $h4aApiHelper,
     ) {
         $this->framework->initialize();
@@ -66,7 +67,7 @@ class UpdateH4aTimelineCron
             // Timeline des Spiels speichern
             H4aTimelineModel::saveTimeline($h4areportparser->timeline, $objEvent->id);
 
-            $this->systemLogger?->info('Timeline aus Bericht Nr. '.$objEvent->sGID
+            $this->contaoCronLogger?->info('Timeline aus Bericht Nr. '.$objEvent->sGID
                     .' für Spiel '.$objEvent->gGameID.' '.$h4areportparser->heim_name.' - '.$h4areportparser->gast_name
                     .' über Handball4all gespeichert');
 


### PR DESCRIPTION
Reports werden seit 01.01.2025 nicht mehr über https://spo.handball4all.de/misc/sboPublicReports.php?sGID=xxxxxxx bereitgestellt und können daher nciht mehr übernommen werden. 

Dieser PR  ergänzt daher das entsprechende Error-Handling.